### PR TITLE
Change data set

### DIFF
--- a/src/components/BasicDiseaseCard.vue
+++ b/src/components/BasicDiseaseCard.vue
@@ -5,7 +5,7 @@
     <v-card-text class="test">
       <div class="mb-4">
         <div class="bd-list">
-          <ul v-for="bd, j in SplitBasicDisease(basic_disease).filter( n => n != '' ).filter( m => m != ' ' )" :key="j">
+          <ul v-for="bd, j in pre_existing_conditions.filter( n => n != '' ).filter( m => m != ' ' )" :key="j">
             <li>{{ bd }}</li>
           </ul>
         </div>
@@ -16,10 +16,8 @@
 </template>
 
 <script setup lang="ts">
-import {SplitBasicDisease} from '@/tools/SplitData'
-
 defineProps<{
-  basic_disease: string
+  pre_existing_conditions: string[]
 }>()
 </script>
 

--- a/src/components/BasicDiseaseRow.vue
+++ b/src/components/BasicDiseaseRow.vue
@@ -1,24 +1,27 @@
 <template>
-	<div v-if="SplitBasicDisease(bd).length > 1">
-		<div v-if="SplitBasicDisease(bd)[0].length >= 10">
-			<span>{{ SplitBasicDisease(bd)[0].substring(0, 7) + '...' }}</span>
+	<div v-if="pre_existing_conditions.length > 1">
+		<div v-if="pre_existing_conditions[0].length >= 10">
+			<span>{{ pre_existing_conditions[0].substring(0, 7) + '...' }}</span>
 		</div>
 		<div v-else>
-			<span>{{ SplitBasicDisease(bd)[0] + '...' }}</span>
+			<span>{{ pre_existing_conditions[0] + '...' }}</span>
 		</div>
     </div>
-	<div v-else>
-		<div v-if="bd.length >= 10">
-			<span>{{ bd.substring(0, 7) + '...' }}</span>
+
+	<div v-else-if="pre_existing_conditions.length == 1">
+		<div v-if="pre_existing_conditions[0].length >= 10">
+			<span>{{ pre_existing_conditions[0].substring(0, 7) + '...' }}</span>
 		</div>
-		<div v-else>{{ bd }}</div>
+		<div v-else>{{ pre_existing_conditions[0] }}</div>
 	</div>
+	
+	<div v-else></div>
 </template>
 
 <script setup lang="ts">
 import {SplitBasicDisease} from '@/tools/SplitData'
 
 defineProps<{
-  bd: string
+  pre_existing_conditions: string[]
 }>()
 </script>

--- a/src/components/BillingDetailsChip.vue
+++ b/src/components/BillingDetailsChip.vue
@@ -1,22 +1,23 @@
 <template>
-	<div v-if="certifiedRelation(billing_type)">
+	<div v-if="certifiedRelation(description_of_claim)">
 		<v-chip color="pink" label>
 			<v-icon start icon="mdi-alert-outline"></v-icon>
-			<span>{{ billing_type }}</span>
+			<span>{{ description_of_claim }}</span>
 		</v-chip>
 	</div>
+	
 	<div v-else>
-		<span>{{ billing_type }}</span>
+		<span>{{ description_of_claim }}</span>
 	</div>
 </template>
 
 <script setup lang="ts">
 defineProps<{
-  billing_type: string
+  description_of_claim: string
 }>()
 
-const certifiedRelation = (bt: string): boolean => {
-	return bt.indexOf('死亡一時金') > -1 || bt.indexOf('葬祭料') > -1
+const certifiedRelation = (dc: string): boolean => {
+	return dc.indexOf('死亡一時金') > -1 || dc.indexOf('葬祭料') > -1
 }
 </script>
 

--- a/src/components/SymptomsCard.vue
+++ b/src/components/SymptomsCard.vue
@@ -5,7 +5,7 @@
     <v-card-text class="test">
       <div class="mb-4">
         <div class="bd-list">
-          <ul v-for="bd, j in SplitSymptoms(symptoms).filter( n => n != '' ).filter( m => m != ' ' )" :key="j">
+          <ul v-for="bd, j in symptoms.filter( n => n != '' ).filter( m => m != ' ' )" :key="j">
             <li>{{ bd }}</li>
           </ul>
         </div>
@@ -20,10 +20,8 @@
 </template>
 
 <script setup lang="ts">
-import {SplitSymptoms} from '@/tools/SplitData'
-
 defineProps<{
-  symptoms: string
+  symptoms: string[]
   clickClose: () => void
 }>()
 </script>

--- a/src/components/SymptomsRow.vue
+++ b/src/components/SymptomsRow.vue
@@ -1,24 +1,23 @@
 <template>
-	<div v-if="SplitSymptoms(sym).length > 1">
-		<div v-if="SplitSymptoms(sym)[0].length >= 10">
-			<span>{{ SplitSymptoms(sym)[0].substring(0, 7) + '...' }}</span>
+	<div v-if="symptoms.length > 1">
+		<div v-if="symptoms[0].length >= 10">
+			<span>{{ symptoms[0].substring(0, 7) + '...' }}</span>
 		</div>
 		<div v-else>
-			<span>{{ SplitSymptoms(sym)[0] + '...' }}</span>
+			<span>{{ symptoms[0] + '...' }}</span>
 		</div>
     </div>
-	<div v-else>
-		<div v-if="sym.length >= 10">
-			<span>{{ sym.substring(0, 7) + '...' }}</span>
+	<div v-else-if="symptoms.length == 1">
+		<div v-if="symptoms[0].length >= 10">
+			<span>{{ symptoms[0].substring(0, 7) + '...' }}</span>
 		</div>
-		<div v-else>{{ sym }}</div>
+		<div v-else>{{ symptoms[0] }}</div>
 	</div>
+	<div v-else></div>
 </template>
 
 <script setup lang="ts">
-import {SplitSymptoms} from '@/tools/SplitData'
-
 defineProps<{
-  sym: string
+  symptoms: string[]
 }>()
 </script>

--- a/src/router/data.ts
+++ b/src/router/data.ts
@@ -7,9 +7,9 @@ export const ReportedMyocarditisDataURL =
 export const ReportedDeathDataURL =
   'https://gist.githubusercontent.com/kaede96az/88e2090c0a0f81615cd37abbfb5474d0/raw/4e865fb0a6a686116e720eb4c549aed02c1f3a21/reported-death-issues.json'
 export const CertifiedHealthHazardDataURL =
-  'https://gist.githubusercontent.com/kaede96az/982f47e9e6613c77af9ba49acf818b7e/raw/a7fcb13544fd94d91d9202a30565eb952219bb62/certified-health-hazards.json'
+  'https://kaede96az.github.io/dashboard-datasets/certified-reports.json'
 export const CertifiedSymptomsDataURL =
-  'https://gist.githubusercontent.com/kaede96az/25e3d9708055f37b2d1fa01c0d0bb4f5/raw/fdf17a8c92b6c6d0381adcc8a2b8586e47a00cc2/certified-symptoms.json'
+  'https://kaede96az.github.io/dashboard-datasets/certified-symptoms.json'
 export const ReportedPfizerDataURL =
   'https://raw.githubusercontent.com/kaede96az/sample-data/main/pfizer.json'
 export const ReportedModernaDataURL =

--- a/src/tools/FilterFunc.ts
+++ b/src/tools/FilterFunc.ts
@@ -9,12 +9,10 @@ export const StringFilterFunc = (value: string, filterVal: ShallowRef<string>): 
   if (nullOrEmptyString(filterVal.value)) return true
 
   //todo
-  //return value.indexOf(filterVal.value) > -1
-  if(value.indexOf(filterVal.value) > -1){
-    return true
-  } else {
-    return false
-  }
+  const targetVal = value.normalize('NFKC')
+  const searchVal = filterVal.value.normalize('NFKC')
+
+  return targetVal.indexOf(searchVal) > -1
 }
 
 export const StringArrayFilterFunc = (values: string[], filterVal: ShallowRef<string>): boolean => {

--- a/src/tools/FilterFunc.ts
+++ b/src/tools/FilterFunc.ts
@@ -1,6 +1,6 @@
 import type { ShallowRef } from 'vue'
 
-const nullOrEmptyString = (value: string): boolean => {
+const nullOrEmptyString = (value: any): boolean => {
   return value == '' || value == null
 }
 
@@ -8,7 +8,26 @@ export const StringFilterFunc = (value: string, filterVal: ShallowRef<string>): 
   // フィルタリング処理が不要な場合はtrueを返すことで、項目を表示させる
   if (nullOrEmptyString(filterVal.value)) return true
 
-  return value.indexOf(filterVal.value) > -1
+  //todo
+  //return value.indexOf(filterVal.value) > -1
+  if(value.indexOf(filterVal.value) > -1){
+    return true
+  } else {
+    return false
+  }
+}
+
+export const StringArrayFilterFunc = (values: string[], filterVal: ShallowRef<string>): boolean => {
+  if (nullOrEmptyString(filterVal.value)) return true
+
+  // 検索文字列がある場合にくる。検索対象が空なら該当しないのでfalseを返す。
+  if(values.length == 0) return false
+
+  for (let index = 0; index < values.length; index++) {
+    if(values[index].indexOf(filterVal.value) > -1) return true
+  }
+
+  return false
 }
 
 export const NumberFilterFunc = (
@@ -38,6 +57,37 @@ export const NumberFilterFunc = (
       return false
     }
   }
+  return true
+}
+
+export const NumberArrayFilterFunc = (
+  values: number[],
+  fromFilterVal: ShallowRef<number>,
+  toFilterVal: ShallowRef<number>
+): boolean => {
+  // フィルタリング処理が不要な場合はtrueを返すことで、項目を表示させる
+  if (nullOrEmptyString(fromFilterVal.value) && nullOrEmptyString(toFilterVal.value)) return true
+  if (values.length == 0) return false
+
+  let result = false
+  if (!nullOrEmptyString(fromFilterVal.value)) {
+    result = false
+    // フィルターの値(from)よりも小さな数ならば非表示にする。フィルターの値(from)と同じ数値は表示する。
+    for (let index = 0; index < values.length; index++) {
+      if( fromFilterVal.value <= values[index]) result = true
+    }
+    if (!result) return false
+  }
+
+  if (!nullOrEmptyString(toFilterVal.value)) {
+    result = false
+    // フィルターの値(to)よりも大きな数ならば非表示にする。フィルターの値(to)と同じ数値は表示する。
+    for (let index = 0; index < values.length; index++) {
+      if( values[index] <= toFilterVal.value) result = true
+    }
+    if (!result) return false
+  }
+
   return true
 }
 
@@ -73,11 +123,5 @@ export const DateFilterFunc = (
 // toDateの方が、より後の日付ならtrueを返す。
 // fromDateとtoDateが同じ日付の場合や、fromDateの方がより後の日付ならfalseを返す。
 const compareDate = (fromDate: Date, toDate: Date): boolean => {
-  if(fromDate.getFullYear() === toDate.getFullYear() &&
-  fromDate.getMonth() === toDate.getMonth() &&
-  fromDate.getDay() === toDate.getDay()) return false
-
-  // 以下の比較演算子による比較だと、同日として文字列から作ったDate型の比較がイコール
-  // にならないため、上記の処理が必要。
-  return fromDate < toDate
+  return fromDate.getTime() < toDate.getTime()
 }

--- a/src/types/CertifiedHealthHazard.ts
+++ b/src/types/CertifiedHealthHazard.ts
@@ -1,14 +1,13 @@
-export interface ICertifiedHealthHazardIssues {
-  issues: ICertifiedHealthHazardIssue[]
-}
-
 export interface ICertifiedHealthHazardIssue {
+  certified_date: string
   gender: string
-  age: number
+  age: number[]
   vaccine_name: string
-  type: string
-  basic_disease: string
-  name: string
-  result: string
-  approved_date: string
+  description_of_claim: string
+  symptoms: string[]
+  judgment_result: string
+  pre_existing_conditions: string[]
+  reasons_for_repudiation: string[]
+  remarks: string
+  source_url: string
 }

--- a/src/types/CertifiedSymptom.ts
+++ b/src/types/CertifiedSymptom.ts
@@ -1,10 +1,10 @@
-export interface ICertifiedSymptoms {
-  issues: ICertifiedSymptom[]
+export interface ICertifiedSymptom {
+  name: string
+  counts: ICounts
 }
 
-export interface ICertifiedSymptom {
-  symptom_name: string
-  male_count: number
-  female_count: number
-  sum_count: number
+export interface ICounts {
+  male: number
+  female: number
+  sum: number
 }

--- a/src/types/FilteredDataAsCsv.ts
+++ b/src/types/FilteredDataAsCsv.ts
@@ -1,18 +1,20 @@
-import { DateFilterFunc, NumberFilterFunc, StringFilterFunc } from "@/tools/FilterFunc"
+import { DateFilterFunc, NumberArrayFilterFunc, NumberFilterFunc, StringArrayFilterFunc, StringFilterFunc } from "@/tools/FilterFunc"
 import { shallowRef, type ShallowRef } from "vue"
 
 export interface IKeyAndFilter {
 	key: string
 	filterType: FilterType
 	valFilter: ShallowRef<string>
-	fromFilter: ShallowRef<string>
-	toFilter: ShallowRef<string>
+	fromFilter: ShallowRef<any>
+	toFilter: ShallowRef<any>
 }
 
 export enum FilterType {
 	String = 0,
-	Number = 1,
-	Date = 2
+	StringArray = 1,
+	Number = 2,
+	NumberArray = 3,
+	Date = 4
 }
 
 export const CreateFilteredData = <T>(keyFilters: IKeyAndFilter[], tableData: ShallowRef<T[] | undefined> | undefined): ShallowRef<T[] | undefined> => {
@@ -28,18 +30,22 @@ export const CreateFilteredData = <T>(keyFilters: IKeyAndFilter[], tableData: Sh
 	keyFilters.forEach(kf => {
 		let val: string = ''
 		filteredData.value = filteredData.value?.filter( (item: any): boolean => {
-			const value = item[kf.key] as string
+			const value = item[kf.key]
 			if(value == undefined) return false
 
 			switch (kf.filterType) {
 				case FilterType.String:
 					return StringFilterFunc(value, kf.valFilter)
+				case FilterType.StringArray:
+					return StringArrayFilterFunc(value, kf.valFilter)
 				case FilterType.Number:
 					val = value
 					if(typeof(val) == typeof('')){
 						val = val.replaceAll('回目', '')
 					}
 					return NumberFilterFunc(val, kf.fromFilter, kf.toFilter)
+				case FilterType.NumberArray:
+					return NumberArrayFilterFunc(value, kf.fromFilter, kf.toFilter)
 				case FilterType.Date:
 					return DateFilterFunc(value, kf.fromFilter, kf.toFilter)
 			

--- a/src/types/FilteredDataAsCsv.ts
+++ b/src/types/FilteredDataAsCsv.ts
@@ -30,7 +30,7 @@ export const CreateFilteredData = <T>(keyFilters: IKeyAndFilter[], tableData: Sh
 	keyFilters.forEach(kf => {
 		let val: string = ''
 		filteredData.value = filteredData.value?.filter( (item: any): boolean => {
-			const value = item[kf.key]
+			const value = getValueFromCompexKey(item, kf.key)
 			if(value == undefined) return false
 
 			switch (kf.filterType) {
@@ -60,17 +60,29 @@ export const CreateFilteredData = <T>(keyFilters: IKeyAndFilter[], tableData: Sh
 	return filteredData
 }
 
+// counts.sum のようにデータが階層構造（countsオブジェクト内のsumプロパティ）でkeyを指定して
+// いるようなケースに対応するため、専用の抽出処理を行う
+const getValueFromCompexKey = (item: any, key: string): any => {
+	const keys = key.split('.')
+	let result = item[keys[0]]
+	for (let index = 1; index < keys.length; index++) {
+		result = result[keys[index]]
+	}
+	return result
+}
+
 export const CreateCsvContent = <T>(filteredData: ShallowRef<T[] |undefined> ,headerTitles: string, headerKeys: string[]): string => {
 	const lineArray: string[] = [headerTitles]
 	filteredData.value?.forEach( (row: any) => {
 		let csvRow = ""
 		let isFirstItem = true
 		headerKeys.forEach(key => {
+			const data = getValueFromCompexKey(row, key)
 			if(isFirstItem){
 				isFirstItem=false
-				csvRow = '"' + row[key] + '"'
+				csvRow = '"' + data + '"'
 			} else {
-				csvRow = csvRow + ',' + '"' + row[key] + '"'
+				csvRow = csvRow + ',' + '"' + data + '"'
 			}
 		});
 		lineArray.push(csvRow);

--- a/src/types/QueryParam.ts
+++ b/src/types/QueryParam.ts
@@ -3,7 +3,7 @@ import router from '@/router/index'
 
 export interface IQueryParam {
 	name: string
-	val: ShallowRef<string>
+	val: ShallowRef<any>
 }
 
 export const CreateUrlWithQueryParams = (queryParamMap: IQueryParam[]): string => {

--- a/src/views/CertifiedSymptomsView.vue
+++ b/src/views/CertifiedSymptomsView.vue
@@ -47,11 +47,11 @@
     density="compact"
     class="data-table-health-hazard"
     :custom-key-filter="{
-      symptom_name: symptomsFilterFunc,
-      sum_count: sumFilterFunc
+      name: symptomsFilterFunc,
+      'counts.sum': sumFilterFunc
     }"
   >
-    <template v-slot:[`item.symptom_name`]="item">
+    <template v-slot:[`item.name`]="item">
       <v-btn variant="text" color="deep-purple-darken-1" @click="navigateWithQuery(item.value)" class="text-none"><b>{{ item.value }}</b></v-btn>
       <span></span>
     </template>
@@ -88,10 +88,10 @@ onMounted(() => {
 })
 
 const headers = [
-  { title: '症状', align: 'start', key: 'symptom_name' },
-  { title: '件数 (男性)', align: 'end', key: 'male_count' },
-  { title: '件数 (女性)', align: 'end', key: 'female_count' },
-  { title: '合計件数', align: 'end', key: 'sum_count' }
+  { title: '症状', align: 'start', key: 'name' },
+  { title: '件数 (男性)', align: 'end', key: 'counts.male' },
+  { title: '件数 (女性)', align: 'end', key: 'counts.female' },
+  { title: '合計件数', align: 'end', key: 'counts.sum' }
 ]
 
 // todo: Navigate先のURLをここに直書きしているため、routes側を変更時に一致しなくなる可能性が・・
@@ -104,9 +104,9 @@ const symptomsFilterFunc = (value: string): boolean => {
   return StringFilterFunc(value, symptomsFilterVal)
 }
 
-const sumFromFilterVal = shallowRef('')
-const sumToFilterVal = shallowRef('')
-const sumFilterFunc = (value: string): boolean => {
+const sumFromFilterVal = shallowRef<any>('')
+const sumToFilterVal = shallowRef<any>('')
+const sumFilterFunc = (value: any): boolean => {
   return NumberFilterFunc(value, sumFromFilterVal, sumToFilterVal)
 }
 
@@ -156,8 +156,8 @@ const searchItems = [
 
 const _blank = shallowRef('')
 const keyAndFilterMap: IKeyAndFilter[] = [
-  { key: "symptom_name", filterType: FilterType.String , valFilter: symptomsFilterVal, fromFilter: _blank, toFilter: _blank},
-  { key: "sum_count", filterType: FilterType.Number , valFilter: _blank, fromFilter: sumFromFilterVal, toFilter: sumToFilterVal},
+  { key: "name", filterType: FilterType.String , valFilter: symptomsFilterVal, fromFilter: _blank, toFilter: _blank},
+  { key: "counts.sum", filterType: FilterType.Number , valFilter: _blank, fromFilter: sumFromFilterVal, toFilter: sumToFilterVal},
 ]
 const downloadFilterdDataAsCsv = () => {
   const filteredData = CreateFilteredData<ICertifiedSymptom>(keyAndFilterMap, dataTableItems)

--- a/src/views/DeathView.vue
+++ b/src/views/DeathView.vue
@@ -90,7 +90,7 @@
     </template>
 
     <template v-slot:[`item.basic_disease`]="item">
-      <BasicDiseaseRow :bd="item.value"></BasicDiseaseRow>
+      <BasicDiseaseRow :pre_existing_conditions="item.value"></BasicDiseaseRow>
     </template>
 
     <template v-slot:expanded-row="{ item }">
@@ -108,7 +108,7 @@
             ></DateAndPT>
           </v-col>
           <v-col cols="12" md="6">
-            <BasicDiseaseCard :basic_disease="item.basic_disease"></BasicDiseaseCard>
+            <BasicDiseaseCard :pre_existing_conditions="item.basic_disease"></BasicDiseaseCard>
           </v-col>
         </v-row>
       </td>

--- a/src/views/MyocarditisView.vue
+++ b/src/views/MyocarditisView.vue
@@ -84,7 +84,7 @@
     </template>
 
     <template v-slot:[`item.basic_disease`]="item">
-      <BasicDiseaseRow :bd="item.value"></BasicDiseaseRow>
+      <BasicDiseaseRow :pre_existing_conditions="item.value"></BasicDiseaseRow>
     </template>
 
     <template v-slot:expanded-row="{ item }">
@@ -102,7 +102,7 @@
             ></DateAndPT>
           </v-col>
           <v-col cols="12" md="6">
-            <BasicDiseaseCard :basic_disease="item.basic_disease"></BasicDiseaseCard>
+            <BasicDiseaseCard :pre_existing_conditions="item.basic_disease"></BasicDiseaseCard>
           </v-col>
         </v-row>
       </td>


### PR DESCRIPTION
`認定一覧`に使用するデータの型を変更する。

「症状」や「基礎疾患」など複数の項目が書かれる内容に関して、区切り文字を認識して配列化する処理はデータを抽出して生成する側でやるべきであり、フロントエンド側で都度分解させるべきではないため。（何万、何億と見てもらう際に、都度ブラウザ側の処理でゴリゴリ文字列を分解するのは無駄。）

変更前後のデータセットの型について以下に示す。

## 認定一覧

### before

```json
  {
    "gender":"女性",
    "age":"85",
    "vaccine_name":"新型コロナ",
    "type":"医療費・医療手当",
    "basic_disease":"-",
    "name":"発熱、血中酸素分圧低下",
    "result":"認定",
    "approved_date":"2022/10/27",
    "no":"1076"
  }
```

### after

```json
  {
    "certified_date": "2022/10/27",
    "gender": "女",
    "age": [
      85
    ],
    "vaccine_name": "新型コロナ",
    "description_of_claim": "医療費・医療手当",
    "symptoms": [
      "発熱",
      "血中酸素分圧低下"
    ],
    "judgment_result": "認定",
    "pre_existing_conditions": [],
    "reasons_for_repudiation": [],
    "remarks": "",
    "source_url": "https://www.mhlw.go.jp/content/10900000/001038819.pdf"
  }
```

## 認定済みの症状一覧

### before

```json
  {
    "symptom_name": "1型糖尿病",
    "male_count": 2,
    "female_count": 0,
    "sum_count": 2
  }
```

### after

```json
  {
    "name": "1型糖尿病",
    "counts": {
      "male": 2,
      "female": 4,
      "sum": 6
    }
  }
```